### PR TITLE
add vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 test/test-bundle.js
 npm-debug.log
 dist
+vendor


### PR DESCRIPTION
vendor is useless for product use but with really a huge size, which slow the download speed
