### PR TITLE
Nested object arrays

### DIFF
--- a/test/docs/test-docs-9.js
+++ b/test/docs/test-docs-9.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var docs = [
+  {
+    _id: '1',
+    list: ['much', 'text', 'goes', 'in this array, you see']
+  },
+  {
+    _id: '2',
+    nested: {
+      array: [{
+        aField: 'something'
+      }]
+    }
+  },
+  {
+    _id: '3',
+    aNumber : 1
+  },
+  {
+    _id: '4',
+    invalid: null
+  },
+  {
+    _id: '5',
+    invalid: {}
+  },
+  {
+    _id: '7',
+    nested: {
+      foo: null
+    }
+  },
+  {
+    _id: '8',
+    nested: {
+      array: null
+    }
+  },
+  {
+    _id: '9',
+    nested: {
+      array: []
+    }
+  },
+  {
+    _id: '10',
+    nested: {
+      array: [{
+        aField: 'something else'
+      },{
+        aField: 'something different'
+      },{
+        aField: 'foobar'
+      }]
+    }
+  }
+];
+
+module.exports = docs;

--- a/test/test.js
+++ b/test/test.js
@@ -572,7 +572,7 @@ function tests(dbName, dbType) {
         };
         return db.search(opts);
       }).then(function (res) {
-        var ids = res.rows.map(function (x) { return x.id; });
+        var ids = res.rows.map(function (x) { return x.id; }).sort().reverse();
         ids.should.deep.equal(['2', '10']);
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,7 @@ var docs5 = require('./docs/test-docs-5');
 var docs6 = require('./docs/test-docs-6');
 var docs7 = require('./docs/test-docs-7');
 var docs8 = require('./docs/test-docs-8');
+var docs9 = require('./docs/test-docs-9');
 
 function tests(dbName, dbType) {
 
@@ -561,6 +562,18 @@ function tests(dbName, dbType) {
       }).then(function (res) {
         var ids = res.rows.map(function (x) { return x.id; });
         ids.should.deep.equal(['2']);
+      });
+    });
+    it('allows searching from an array of nested objects', function () {
+      return db.bulkDocs({docs: docs9}).then(function () {
+        var opts = {
+          fields: ['nested.array[].aField'],
+          query: 'something'
+        };
+        return db.search(opts);
+      }).then(function (res) {
+        var ids = res.rows.map(function (x) { return x.id; });
+        ids.should.deep.equal(['2', '10']);
       });
     });
     it('allows searching string arrays', function () {


### PR DESCRIPTION
Adds support for field definitions like `my.nested.array[].with.field`

For documents like 
```json
{
  "my": {
    "nested": {
      "array":[{
        "with": { "field": "something" }
       }]
      }
    }
  }
}
```

it will loop through all objects in `my.nested.array` and index their `with.field` values.

This fixes #32 