### PR TITLE
Add lunr.js options when building the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ API
 * [Minimum should match (mm)](#minimum-should-match-mm)
 * [Filtering documents](#filtering-documents)
 * [Building the index](#building-the-index)
+* [Passing Options to lunr.js during build](#passing-options-to-lunr.js-during-build)
 * [Deleting the index](#deleting-the-index)
 * [Stale queries](#stale-queries)
 * [Other languages](#other-languages)
@@ -421,6 +422,23 @@ pouch.search({
 This will build up the index without querying it. If the database has changed since you last updated (e.g. new documents were added), then it will simply update the index with the new documents. If nothing has changed, then it won't do anything.
 
 You must at least provide the `fields` you want to index.  If the language isn't English, you must pass in the `language` option.  Boosts don't matter.
+
+### Passing Options to lunr.js during build
+
+You can pass in options to lunr.js during the index build by adding a `lunrOptions` option to the search. `lunrOptions` is a function whereby you can access the lunr instance via `this` from within the function. For example, if you wanted to add a function to the pipeline, you could do it like so:
+
+```js
+pouch.search({
+  fields: ['title', 'text'],
+  build: true,
+  lunrOptions: function(){
+    this.pipeline.add(function (token, tokenIndex, tokens) {
+      // text processing in here
+    })
+  }
+});
+```
+More info on the lunr.js methods available here: http://lunrjs.com/docs/
 
 ### Deleting the index
 

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ exports.search = utils.toPromise(function (opts, callback) {
   var stale = opts.stale;
   var limit = opts.limit;
   var build = opts.build;
+  var lunrOptions = build ? opts.lunrOptions : null;
   var skip = opts.skip || 0;
   var language = opts.language || 'en';
   var filter = opts.filter;
@@ -125,7 +126,7 @@ exports.search = utils.toPromise(function (opts, callback) {
 
   var index = indexes[language];
   if (!index) {
-    index = indexes[language] = lunr();
+    index = indexes[language] = lunr(lunrOptions);
     if (language !== 'en') {
       index.use(global.lunr[language]);
     }


### PR DESCRIPTION
It’d be handy if you could pass in lunr.js options when you build the index. For example, if you wanted to add a new pipeline function, or if you didn't want any of the default pipeline functions that come with calling lunr().