### PR TITLE
Unstable JSON.stringify used for persisted index name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var utils = require('./pouch-utils');
 var lunr = require('lunr');
 var uniq = require('uniq');
 var Promise = utils.Promise;
+var stringify = require('json-stable-stringify');
 
 var indexes = {};
 
@@ -148,7 +149,7 @@ exports.search = utils.toPromise(function (opts, callback) {
     indexParams.filter = filter.toString();
   }
 
-  var persistedIndexName = 'search-' + utils.MD5(JSON.stringify(indexParams));
+  var persistedIndexName = 'search-' + utils.MD5(stringify(indexParams));
 
   var mapFun = createMapFunction(fieldBoosts, index, filter, pouch);
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "argsarray": "0.0.1",
     "es3ify": "^0.1.3",
     "inherits": "~2.0.1",
+    "json-stable-stringify": "^1.0.1",
     "lie": "^2.6.0",
     "lunr": "0.7.1",
     "md5-jkmyers": "0.0.1",


### PR DESCRIPTION
Just from reading the code, this looks a bit scary:

[`var persistedIndexName = 'search-' + utils.MD5(JSON.stringify(indexParams));`](https://github.com/nolanlawson/pouchdb-quick-search/blob/372f4228ed5ed7230a55a52c4e7088a231eb234c/lib/index.js#L151)

Because (at least in theory) [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) could change its output:

> Properties of non-array objects are not guaranteed to be stringified in any particular order. Do not rely on ordering of properties within the same object within the stringification.

This could then result in rebuilding the full index, I guess? Using something like [`json-stable-stringify`](https://www.npmjs.com/package/json-stable-stringify) would thus seem appropriate.