### PR TITLE
Add safety check for highlighting where field is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -414,12 +414,14 @@ function applyHighlighting(pouch, opts, rows, fieldBoosts,
         var text = getText(fieldBoost, doc);
         // TODO: this is fairly naive highlighting code; could improve
         // the regex
-        Object.keys(queryTerms).forEach(function (queryTerm) {
-          var regex = new RegExp('(' + queryTerm + '[a-z]*)', 'gi');
-          var replacement = pre + '$1' + post;
-          text = text.replace(regex, replacement);
-          row.highlighting[fieldName] = text;
-        });
+        if (text) {
+          Object.keys(queryTerms).forEach(function (queryTerm) {
+            var regex = new RegExp('(' + queryTerm + '[a-z]*)', 'gi');
+            var replacement = pre + '$1' + post;
+            text = text.replace(regex, replacement);
+            row.highlighting[fieldName] = text;
+          });
+        }  
       });
     });
   })).then(function () {


### PR DESCRIPTION
Using the following search options:
```javascript
const opts = {
    query: queryParam,
    fields: ['field1', 'field2'],
    include_docs: true,
    highlighting: true,
  };
```

If `field1` matches the queryParam, but `field2` does not exist in the document, then the following exception is thrown:
```
TypeError: Cannot read property 'replace' of undefined
    at \node_modules\pouchdb-quick-search\lib\index.js:421:23
    at Array.forEach (<anonymous>)
    at \node_modules\pouchdb-quick-search\lib\index.js:418:33
    at Array.forEach (<anonymous>)
    at \node_modules\pouchdb-quick-search\lib\index.js:411:42
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Some documents in the database do not have field2. 

This small check will allow for search and highlighting with inconsistent DB schema.